### PR TITLE
oerplib3: Fix ConfigParser import for Python 3.12

### DIFF
--- a/oerplib3/tools/session.py
+++ b/oerplib3/tools/session.py
@@ -30,7 +30,11 @@ import sys
 if sys.version_info[0] == 2:
     from ConfigParser import SafeConfigParser
 else:
-    from configparser import SafeConfigParser
+    try:
+        from configparser import SafeConfigParser
+    except:
+        # Python 3.12 +
+        from configparser import ConfigParser as SafeConfigParser
 
 from oerplib3 import error
 


### PR DESCRIPTION
This little change makes oerplib3 work with newer Python versions where `SafeConfigParser` is no longer available.

Thanks for your work on oerplib3!